### PR TITLE
Adding alias for bot's app config class

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Define application in ```INSTALLED_APPS```
 ```
     INSTALLED_APPS = [
         ...
-        'django_telegram.bot',
+        'django_telegram',
         ...
     ]
 ```

--- a/django_telegram/__init__.py
+++ b/django_telegram/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'django_telegram.bot.apps.TelegramBotConfig'  # pragma: no cover

--- a/django_telegram/bot/apps.py
+++ b/django_telegram/bot/apps.py
@@ -11,7 +11,7 @@ from django_telegram.bot.constants import (
 
 
 class TelegramBotConfig(AppConfig):  # pragma: no cover
-    name = 'django_telegram.bot'
+    name = 'django_telegram'
     verbose_name = "Django Telegram Bot"
 
     def ready(self):


### PR DESCRIPTION
Adding alias for bot's app config class, so that we can put just  django_telegram in INSTALLED_APPS instead of full FQDN for TelegramBotConfig class